### PR TITLE
Create coercing-to-a-string.js

### DIFF
--- a/coercing-to-a-string.js
+++ b/coercing-to-a-string.js
@@ -1,0 +1,11 @@
+// We can quickly coerce a value to a string by wrapping it in a template literal:
+
+const num = 2
+
+const numString = `${num}`
+
+// output:
+
+// {num: 2, numString: "2"}
+
+console.log({ num, numString })


### PR DESCRIPTION
We can quickly coerce a value to a string by wrapping it in a template literal.